### PR TITLE
Utilize OpenJDK8 for Alpine OS

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ sonarscannercli_mirror: https://binaries.sonarsource.com/Distribution/sonar-scan
 sonarscannercli_os: linux
 sonarscannercli_checksums:
   '4.0.0.1744':
+    # https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.0.0.1744.zip
+    alpine: sha256:1ca11d59a122a8d2b492397cedfc63cf9072fe863841397e7ffd1b2d39bef0b4
     # https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.0.0.1744-linux.zip
     linux: sha256:0bf5a5e8fa96198cf3ab8375d19e34853df0e1b5e32de1974f3bbf8cab232624
     # https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.0.0.1744-macosx.zip

--- a/tasks/Alpine.yml
+++ b/tasks/Alpine.yml
@@ -1,0 +1,4 @@
+- name: '{{ansible_os_family}} - Install openjdk8-jre'
+  apk:
+    name: openjdk8-jre
+    state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,7 @@
 
 - name: run installation prerequisites based on OS family
   include_tasks: '{{ role_path }}/tasks/{{ ansible_os_family }}.yml'
+  when: ansible_os_family == 'Alpine'
 
 - name: look for install..
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,8 +12,6 @@
 
 - name: run installation prerequisites based on OS family
   include_tasks: '{{ role_path }}/tasks/{{ ansible_os_family }}.yml'
-  loop_control:
-  loop_var: os_based_installation_task
 
 - name: look for install..
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,12 @@
       skip: true
       paths:
         - '{{ role_path }}/vars'
+
+- name: run installation prerequisites based on OS family
+  include_tasks: '{{ role_path }}/tasks/{{ ansible_os_family }}.yml'
+  loop_control:
+  loop_var: os_based_installation_task
+
 - name: look for install..
   become: yes
   stat:

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -1,0 +1,3 @@
+---
+sonarscannercli_os: alpine
+sonarscannercli_platform: '{{ sonarscannercli_ver }}'


### PR DESCRIPTION
SonarScanner CLI - Linux contains an embedded JRE which is incompatible with Alpine OS distributions due to incompatible c libraries; consequently, force Alpine OS builds to install OpenJDK8 JRE to bypass issues with the packaged AdaptOpenJDK 11 supplied by Sonar.