### PR TITLE
Allow for SonarScanner CLI Caching Plugins at Installation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,3 +14,6 @@ sonarscannercli_checksums:
     # https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.0.0.1744-windows.zip
     windows: sha256:ff33485ff8722a654443463c2547f087a29dfc0a27876a38d1e0ee79144772b7
 sonarscannercli_parent_install_dir: /usr/local
+
+sonarscannercli_host_url: http://localhost:9000
+sonarscannercli_cache_warmup: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,3 +57,7 @@
     src: '{{ item.f }}.j2'
     dest: '{{ item.d }}/{{ item.f }}'
     mode: '{{ item.m | default(0644) }}'
+- name: warmup cache
+  when: sonarscannercli_cache_warmup
+  shell: sonar-scanner -Dsonar.host.url={{ sonarscannercli_host_url }} --debug
+  ignore_errors: True


### PR DESCRIPTION
Issue #3 